### PR TITLE
Update Dockerfile to build an image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.5 as builder
+
+WORKDIR /tmp/redash-query-replace
+COPY . /tmp/redash-query-replace
+RUN gem build redash-query-replace.gemspec
+
+FROM ruby:2.5
 
 WORKDIR /work
-COPY . /work/
-
-RUN apk update && \
-	apk upgrade && \
-	apk add --no-cache git gcc g++ libc-dev linux-headers make
-
-RUN source bin/setup && rake spec && bundle exec rake install
-
-ARG REDASH_URL
-ARG REDASH_API_KEY
-ENV REDASH_URL $REDASH_URL
-ENV REDASH_API_KEY $REDASH_API_KEY
+COPY --from=builder /tmp/redash-query-replace/redash-query-replace-0.0.1.gem .
+RUN gem install redash-query-replace-0.0.1.gem
 
 ENTRYPOINT ["redash-qr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
 FROM ruby:2.5-alpine
 
-ARG version
+WORKDIR /work
+COPY . /work/
 
-RUN if [[ "$version" = "" ]]; then gem install redash-query-replace --no-document; else gem install redash-query-replace --no-document --version ${version}; fi
+RUN apk update && \
+	apk upgrade && \
+	apk add --no-cache git gcc g++ libc-dev linux-headers make
+
+RUN source bin/setup && rake spec && bundle exec rake install
+
+ARG REDASH_URL
+ARG REDASH_API_KEY
+ENV REDASH_URL $REDASH_URL
+ENV REDASH_API_KEY $REDASH_API_KEY
 
 ENTRYPOINT ["redash-qr"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ And then execute:
 Or install it yourself as:
 
     $ gem install redash-query-replace
+	
+### Use Docker	
+
+Build docker image on local
+```
+docker build -t ${USER}/redash-rp --build-arg REDASH_URL=<your redash url> --build-arg REDASH_API_KEY=<your redash api key>
+```
+
+Run docker image
+```
+docker run --rm -v `pwd`/:/vol ${USER}/redash-rp query --from 'database.table1' --to 'database.table2' --id 5
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,6 @@ Or install it yourself as:
 
     $ gem install redash-query-replace
 	
-### Use Docker	
-
-Build docker image on local
-```
-docker build -t ${USER}/redash-rp --build-arg REDASH_URL=<your redash url> --build-arg REDASH_API_KEY=<your redash api key>
-```
-
-Run docker image
-```
-docker run --rm -v `pwd`/:/vol ${USER}/redash-rp query --from 'database.table1' --to 'database.table2' --id 5
-```
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/spec/redash/query/replace_spec.rb
+++ b/spec/redash/query/replace_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe Redash::Query::Replace do
   it "has a version number" do
     expect(Redash::Query::Replace::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Update Dockerfile to install on local environment.

`civitaspo/redash-qr` dose not exist on dockerhub. So I need to build a docker image. 

- Run an [instruction on README](https://github.com/civitaspo/redash-query-replace#development) on Dockerfile.
- Remove "does something useful" from spec/redash/query/replace_spec.rb.

